### PR TITLE
Split into chunks more efficiently

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .idea
+node_modules

--- a/test.js
+++ b/test.js
@@ -18,9 +18,17 @@ module.exports = (config, beforeHandler) => {
         const arrayFromObject = Object.entries(stories).map(([key, value]) => ({
           [key]: value,
         }));
-        const workerChunk = arrayFromObject.filter((value, index) => (index % totalWorkers) === worker - 1);
+        const size = Math.floor(arrayFromObject.length / totalWorkers);
+        const leftOvers = arrayFromObject.length % totalWorkers;
+        const slicing = Array.from(
+          Array(totalWorkers + 1).keys(),
+          (i) => size * i + Math.min(leftOvers, i)
+        );
+        const workerChunk = arrayFromObject.slice(
+          ...slicing.slice(worker - 1, worker + 1)
+        );
         storiesChunk = workerChunk.reduce(
-          (acc, cur) => ({...acc, ...cur}),
+          (acc, cur) => ({ ...acc, ...cur }),
           {}
         );
       }

--- a/test.js
+++ b/test.js
@@ -1,4 +1,3 @@
-const _ = require('lodash');
 const {setup} = require('detox-applitools-testing');
 
 const setupChannel = require('./utils/channel');
@@ -16,13 +15,11 @@ module.exports = (config, beforeHandler) => {
 
       let storiesChunk = stories;
       if (worker && totalWorkers) {
-        const storiesLength = Object.keys(stories).length;
-        const chunkSize = Math.ceil(storiesLength / totalWorkers);
         const arrayFromObject = Object.entries(stories).map(([key, value]) => ({
           [key]: value,
         }));
-        const storiesByChunk = _.chunk(arrayFromObject, chunkSize);
-        storiesChunk = storiesByChunk[worker - 1].reduce(
+        const workerChunk = arrayFromObject.filter((value, index) => (index % totalWorkers) === worker - 1);
+        storiesChunk = workerChunk.reduce(
           (acc, cur) => ({...acc, ...cur}),
           {}
         );


### PR DESCRIPTION
For example for 19 tasks and 6 workers current implementation creates 4 chunks of size 4 and one chunk of size 3, leaving worker #6 without any tasks.
The new implementation splits tasks into 1 chunk of size 4 and 5 chunks of size 3.

@emilisb the new implementation would split tests into more evenly sized groups and [prevent crashing](http://tc.dev.wixpress.com/viewLog.html?tab=buildLog&logTab=tree&filter=debug&expand=all&buildId=128156322&_focus=2074), but it does a lot of test scattering. The old implementation chunks like this: [#1, #2, #3] [#4, #5, #6], the new: [#1, #3, #5] [#2, #4, #6]. Do you think this scattering could cause problems?